### PR TITLE
Bug 1224177 - remove old aws-provisioner

### DIFF
--- a/assets/uptime.js
+++ b/assets/uptime.js
@@ -18,10 +18,6 @@ var MONITORS = [
     name:     'auth.taskcluster.net',
     key:      'm776208480-28abc3b309cb0e526a5ebce8'
   }, {
-    title:    'aws-provisioner.taskcluster.net',
-    name:     'provisioner',
-    key:      'm776120201-37b5da206dfd8de4b00ae25b'
-  }, {
     title:    'events.taskcluster.net',
     name:     'events.taskcluster.net',
     key:      'm776321033-e82bb32adfa08a0bba0002c6'


### PR DESCRIPTION
We should remove the old provisioner since we no longer care about it
